### PR TITLE
feat: Added support for rg (ripgrep) search in mvtn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 EMACS = emacs
 VERSION = 0.1
-EL = mvtn.el mvtn-ag.el mvtn-pkg.el
+EL = mvtn.el mvtn-ag.el mvtn-rg.el mvtn-pkg.el
 TEST = test/mvtn-test.el test/mvtn-test-helpers.el
 
 # ----------------------------------------------------------------------
@@ -26,6 +26,7 @@ clean:
 # ----------------------------------------------------------------------
 mvtn-test.elc: mvtn.el test/mvtn-test-helpers.el test/mvtn-test.el
 mvtn-ag.elc: mvtn.el
+mvtn-rg.elc: mvtn.el
 
 
 # ----------------------------------------------------------------------

--- a/mvtn-rg.el
+++ b/mvtn-rg.el
@@ -1,0 +1,34 @@
+;;; mvtn-rg.el --- Support for rg (ripgrep) for mvtn -*- lexical-binding: t -*-
+
+;;; Commentary:
+
+;; This file may be loaded in addition to mvtn's core (mvtn.el) to add support
+;; for rg (ripgrep) (https://github.com/BurntSushi/ripgrep)
+;; using rg.el (https://github.com/dajva/rg.el).
+
+;;; Code:
+
+(require 'mvtn)
+
+(declare-function rg "ext:rg")
+(defvar rg-executable)
+
+;;;###autoload
+(defun mvtn-search-full-text-rg (string exclude-dirs)
+  "Searches STRING using `rg' in `default-directory',
+excluding directories specified as a list of strings in
+DIRS. Fall back to `mvtn-search-full-text--grep' when
+`rg-executable' is not found."
+  (require 'rg)
+  (if (not (executable-find rg-executable))
+      (mvtn-search-full-text-grep string exclude-dirs)
+    (let ((rg-command-line-flags
+           (mapcar
+            (lambda (dir) (format "-g=!%s" dir))
+            exclude-dirs)))
+    (rg string "everything" default-directory))))
+
+
+(provide 'mvtn-rg)
+
+;;; mvtn-rg.el ends here

--- a/mvtn-rg.el
+++ b/mvtn-rg.el
@@ -12,6 +12,7 @@
 
 (declare-function rg "ext:rg")
 (defvar rg-executable)
+(defvar rg-command-line-flags)
 
 ;;;###autoload
 (defun mvtn-search-full-text-rg (string exclude-dirs)


### PR DESCRIPTION
Now mvtn is able to use the rg.el package for its search across notes.