### PR TITLE
Compatibility with emacs 26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,20 @@ test: compile
 
 
 # ----------------------------------------------------------------------
+# load in default emacs
+# ----------------------------------------------------------------------
+run: compile
+	cd test && \
+	$(EMACS) -Q --debug-init -L .. -L . \
+	-l mvtn-test.el \
+	-l mvtn-test-file-helpers.el \
+	--eval '(setq mvtn-note-directory mvtn-test-note-dir)' \
+	--eval '(mvtn-test-with-testfiles t)' \
+	--eval '(find-file "mvtn-test.el")' \
+	--eval '(split-window)' \
+	--eval '(dired mvtn-note-directory)'
+
+# ----------------------------------------------------------------------
 # packaging
 # ----------------------------------------------------------------------
 mvtn-$(VERSION).tar: $(EL)

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ EMACS   = emacs
 VERSION = 0.1
 EL      = mvtn.el \
           mvtn-compat.el \
-	      mvtn-file-helpers.el \
-	      mvtn-ag.el \
-	      mvtn-rg.el
+          mvtn-file-helpers.el \
+          mvtn-ag.el \
+          mvtn-rg.el
 TEST    = test/mvtn-test.el \
-	      test/mvtn-test-helpers.el \
-	      test/mvtn-test-file-helpers.el
+          test/mvtn-test-helpers.el \
+          test/mvtn-test-file-helpers.el
 
 # ----------------------------------------------------------------------
 # compile

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .SUFFIXES = .elc .el
 
-EMACS = emacs
+EMACS   = emacs
 VERSION = 0.1
-EL = mvtn.el \
-	mvtn-file-helpers.el \
-	mvtn-ag.el \
-	mvtn-rg.el \
-	mvtn-pkg.el
-TEST = test/mvtn-test.el \
-	test/mvtn-test-helpers.el \
-	test/mvtn-test-file-helpers.el
+EL      = mvtn.el \
+          mvtn-compat.el \
+	      mvtn-file-helpers.el \
+	      mvtn-ag.el \
+	      mvtn-rg.el
+TEST    = test/mvtn-test.el \
+	      test/mvtn-test-helpers.el \
+	      test/mvtn-test-file-helpers.el
 
 # ----------------------------------------------------------------------
 # compile
@@ -30,6 +30,7 @@ clean:
 # ----------------------------------------------------------------------
 # dependencies
 # ----------------------------------------------------------------------
+mvtn.elc: mvtn-compat.el
 mvtn-test.elc: mvtn.el test/mvtn-test-helpers.el
 mvtn-test-file-helpers.elc: mvtn.el test/mvtn-test-helpers.el test/mvtn-test.el
 mvtn-file-helpers.elc: mvtn.el

--- a/mvtn-compat.el
+++ b/mvtn-compat.el
@@ -6,7 +6,7 @@
 (defun mvtn-list-files-function-native (&optional search)
   "Native (elisp) implementation for `mvtn-list-files-function'.
 Does not show hidden files (prefixed with '.').
-Emacs <27 compatibility - less performant since it needs to traverse all
+Emacs <27 compatibility: less performant since it needs to traverse all
 excluded directories and only filters afterwards."
   (mapcar (lambda (file-name)
             (substring file-name (1+ (length default-directory))))

--- a/mvtn-compat.el
+++ b/mvtn-compat.el
@@ -1,0 +1,27 @@
+;;; mvtn-compat.el --- Support for emacs <27 for mvtn -*- lexical-binding: t -*-
+
+(require 'seq)
+(defvar mvtn-excluded-directories)
+
+(defun mvtn-list-files-function-native (&optional search)
+  "Native (elisp) implementation for `mvtn-list-files-function'.
+Does not show hidden files (prefixed with '.').
+Emacs <27 compatibility - less performant since it needs to traverse all
+excluded directories and only filters afterwards."
+  (mapcar (lambda (file-name)
+            (substring file-name (1+ (length default-directory))))
+          (seq-filter (lambda (file)
+                        (not (member
+                              nil (mapcar (lambda (dir) (not (string-match-p
+                                                         (format "/%s/" dir) file)))
+                                          mvtn-excluded-directories))))
+                      (sort (directory-files-recursively
+                             "." (if search
+                                     (format "^[^\\.]*%s" search)
+                                   "^[^\\.]")
+                             nil)
+                            'string<))))
+
+(provide 'mvtn-compat)
+
+;;; mvtn-compat.el ends here

--- a/mvtn.el
+++ b/mvtn.el
@@ -213,12 +213,10 @@ Does not show hidden files (prefixed with '.')"
   (mapcar (lambda (file-name)
             (substring file-name 2))
           (sort (directory-files-recursively
-           "." (if search
-                   (format "^[^\\.]*%s" search)
-                 "^[^\\.]") nil
-           (lambda (dir-name)
-             (not (member (file-name-nondirectory dir-name)
-                          mvtn-excluded-directories)))) 'string<)))
+                 "." (if search (format "^[^\\.]*%s" search) "^[^\\.]") nil
+                 (lambda (dir-name)
+                   (not (member (file-name-nondirectory dir-name)
+                                mvtn-excluded-directories)))) 'string<)))
 
 
 (defun mvtn-list-files-function-find (&optional search)
@@ -272,7 +270,7 @@ recursively. Limit to `mvtn-search-years' unless ALL is non-nil."
   "Use `mvtn-generate-file-name' to create a new file.
 RETURN the full name of the newly created file."
   (let ((file-name (mvtn-generate-file-name timestamp title extension tags encrypt)))
-   (write-region "" nil file-name) file-name))
+    (write-region "" nil file-name) file-name))
 
 (defun mvtn-create-new-file (title tags &optional encrypt no-template)
   "Use `mvtn-touch-new-file' to create a new file, insert a

--- a/mvtn.el
+++ b/mvtn.el
@@ -328,7 +328,7 @@ Example:
   (let* ((timestamp (mvtn--extract-note-identity link))
          (year-dir (mvtn-timestamp-field timestamp 'year))
          (matches '()))
-    (dolist (current-dir (flatten-list (cons year-dir mvtn-static-note-directories)))
+    (dolist (current-dir `(,year-dir ,@mvtn-static-note-directories))
       (let ((default-directory (format "%s/%s" mvtn-note-directory current-dir)))
         (setq matches (append matches
                               (mapcar (lambda (filename)
@@ -466,6 +466,8 @@ used to encrypt the file with gpg."
   (let* ((default-directory mvtn-note-directory)
          (answer (completing-read "Open note: " (mvtn-list-files all))))
     (find-file answer)))
+
+(when (< emacs-major-version 27) (require 'mvtn-compat))
 
 (provide 'mvtn)
 

--- a/mvtn.el
+++ b/mvtn.el
@@ -291,20 +291,19 @@ the buffer to the resulting file. RETURN that buffer."
     buf))
 
 
-(defun mvtn--extract-note-identity (noteid &optional notename)
-  "Extracts the timestamp from NOTEID (any string representation
-of a note's name). When NOTENAME is given, also extracts the
+(defun mvtn--extract-note-identity (notename &optional filename)
+  "Extracts the timestamp from NOTENAME (any string representation
+of a note's name). When FILENAME is given, also extracts the
 filename without filextension and tags"
-  (when (not
-         (if notename
-             (string-match "[[:digit:]]\\{8\\}-[[:digit:]]\\{6\\} .+" noteid)
-           (string-match "[[:digit:]]\\{8\\}-[[:digit:]]\\{6\\}" noteid)))
+  (unless (if filename
+              (string-match "[[:digit:]]\\{8\\}-[[:digit:]]\\{6\\} [^\\^\\.]*" notename)
+            (string-match "[[:digit:]]\\{8\\}-[[:digit:]]\\{6\\}" notename))
     (error (concat "Failed to extract note identity. "
                    "Probably an invalid filename or timestamp: %s")
-           noteid))
-  (let* ((match (match-string-no-properties 0 noteid))
+           notename))
+  (let* ((match (match-string-no-properties 0 notename))
          (sep (if (string-match-p "--" match) "--" "\\.")))
-    (string-trim (car (split-string match sep)) nil "[\\^ ]+")))
+    (string-trim (car (split-string match sep)))))
 
 
 (defun mvtn-link-targets (link)

--- a/test/mvtn-test-file-helpers.el
+++ b/test/mvtn-test-file-helpers.el
@@ -6,7 +6,7 @@
 
 (ert-deftest mvtn-test-rename-current-file ()
   "Test `mvtn-rename-current-file'"
-  (mvtn-test-with-testfiles
+  (mvtn-test-with-testfiles nil
    (let ((orig-file (concat mvtn-test-note-dir
                             "/1999/19990110-134522 test2 test2.txt"))
          (should-new-file (concat mvtn-test-note-dir

--- a/test/mvtn-test-helpers.el
+++ b/test/mvtn-test-helpers.el
@@ -23,7 +23,8 @@ timestamp. Example:
 
 (defmacro mvtn-test-with-testfiles (no-delete &rest body)
   `(let ((mvtn-note-directory mvtn-test-note-dir))
-     (delete-directory mvtn-test-note-dir t)
+     (when (file-exists-p mvtn-test-note-dir)
+       (delete-directory mvtn-test-note-dir t))
      (mkdir mvtn-test-note-dir) (cd mvtn-test-note-dir)
      (mkdir "1999") (cd "1999")
      (mvtn-test-touch "19990110-134522 test1 -- tags test.txt")

--- a/test/mvtn-test-helpers.el
+++ b/test/mvtn-test-helpers.el
@@ -21,7 +21,7 @@ timestamp. Example:
   (write-region "" nil filename))
 
 
-(defmacro mvtn-test-with-testfiles (&rest body)
+(defmacro mvtn-test-with-testfiles (no-delete &rest body)
   `(let ((mvtn-note-directory mvtn-test-note-dir))
      (delete-directory mvtn-test-note-dir t)
      (mkdir mvtn-test-note-dir) (cd mvtn-test-note-dir)
@@ -69,7 +69,7 @@ And some more content."
      (mvtn-test-touch "20140210-134522 a note for work 2.org")
      (cd "../../..")
      (let ((result (progn ,@body)))
-       (delete-directory mvtn-test-note-dir t)
+       (when (not ,no-delete) (delete-directory mvtn-test-note-dir t))
        result)))
 
 (provide 'mvtn-test-helpers)

--- a/test/mvtn-test-helpers.el
+++ b/test/mvtn-test-helpers.el
@@ -1,5 +1,7 @@
 ;;; mvtn-test-helpers.el --- Helpers for mvtn unit test -*- lexical-binding: t -*-
 
+(require 'seq)
+
 (defun mvtn-test-file-exists-disregarding-timestamp-p (filename dir)
   "Check wether FILENAME exists in DIR, disregarding mvtn
 timestamps. Therefore, TIMESTAMP has to be provided *without* the

--- a/test/mvtn-test.el
+++ b/test/mvtn-test.el
@@ -51,7 +51,8 @@ files. Mocking seemed like too much of a hassle here.")
 
 (ert-deftest mvtn-test-get-create-current-note-directory ()
   "Test `mvtn-get-create-current-year-directory'"
-  (delete-directory mvtn-test-note-dir t)
+  (when (file-exists-p mvtn-test-note-dir)
+    (delete-directory mvtn-test-note-dir t))
   (let ((mvtn-note-directory mvtn-test-note-dir))
     (should (not (file-exists-p mvtn-note-directory)))
     (should (string-equal (mvtn-get-create-current-year-directory)
@@ -66,7 +67,8 @@ files. Mocking seemed like too much of a hassle here.")
 
 (ert-deftest mvtn-test-create-new-file ()
   "Test `mvtn-create-new-file'"
-  (delete-directory mvtn-test-note-dir t)
+  (when (file-exists-p mvtn-test-note-dir)
+    (delete-directory mvtn-test-note-dir t))
   (let ((mvtn-note-directory mvtn-test-note-dir)
         (mvtn-default-file-extension "test"))
     (mvtn-create-new-file "My Note Title" "tag1 tag2")

--- a/test/mvtn-test.el
+++ b/test/mvtn-test.el
@@ -113,7 +113,7 @@ files. Mocking seemed like too much of a hassle here.")
   (let ((mvtn-list-files-function 'mvtn-list-files-function-native))
     (should (string-equal
              (mapconcat 'identity
-                        (mvtn-test-with-testfiles (mvtn-list-files)) "\n")
+                        (mvtn-test-with-testfiles nil (mvtn-list-files)) "\n")
              "2021/20210110-134524 test3 test3.org
 2021/20210110-134523 test2 test2.txt
 2021/20210110-134522 test1 -- i have tags.md
@@ -127,7 +127,7 @@ static/20130210-134522 an old statically displayed note.org
 static/20130210-134522 an old statically displayed note.md"))
     (should (string-equal
              (mapconcat 'identity
-                        (mvtn-test-with-testfiles (mvtn-list-files t)) "\n")
+                        (mvtn-test-with-testfiles nil (mvtn-list-files t)) "\n")
              "2021/20210110-134524 test3 test3.org
 2021/20210110-134523 test2 test2.txt
 2021/20210110-134522 test1 -- i have tags.md
@@ -152,7 +152,7 @@ static/20130210-134522 an old statically displayed note.md"))))
     (let ((mvtn-list-files-function 'mvtn-list-files-function-find))
       (should (string-equal
                (mapconcat 'identity
-                          (mvtn-test-with-testfiles (mvtn-list-files)) "\n")
+                          (mvtn-test-with-testfiles nil (mvtn-list-files)) "\n")
                "2021/20210110-134524 test3 test3.org
 2021/20210110-134523 test2 test2.txt
 2021/20210110-134522 test1 -- i have tags.md
@@ -166,7 +166,7 @@ static/20130210-134522 an old statically displayed note.org
 static/20130210-134522 an old statically displayed note.md"))
       (should (string-equal
                (mapconcat 'identity
-                          (mvtn-test-with-testfiles (mvtn-list-files t)) "\n")
+                          (mvtn-test-with-testfiles nil (mvtn-list-files t)) "\n")
                "2021/20210110-134524 test3 test3.org
 2021/20210110-134523 test2 test2.txt
 2021/20210110-134522 test1 -- i have tags.md
@@ -188,7 +188,7 @@ static/20130210-134522 an old statically displayed note.md")))))
 
 (ert-deftest mvtn-test-link-targets ()
   "Test `mvtn-link-targets'"
-  (mvtn-test-with-testfiles
+  (mvtn-test-with-testfiles nil
    (should (mvtn-link-targets "^^20210110-134524 test3 test3.org^^"))
    (should (mvtn-link-targets "^^20210110-134524 test3 test3^^"))
    (should (mvtn-link-targets "^^20210110-134524^^"))
@@ -204,7 +204,7 @@ static/20130210-134522 an old statically displayed note.md")))))
 
 (ert-deftest mvtn-test-link-action-search ()
   "Test `mvtn-link-actions' and `mvtn-link-action-search'"
-  (mvtn-test-with-testfiles
+  (mvtn-test-with-testfiles nil
    (mvtn-follow-link "^^20181212-134541^^")
    (mvtn-follow-link "^^20181212-134541 :: content^^")
    (should (string-equal (word-at-point) "content"))


### PR DESCRIPTION
- new file `mvtn-compat.el` that gets loaded when emacs-major-version < 27 -> fixes emacs 26 compatibility
- new make target `run` to allow interactive debugging of mvtn in default emacs -> intended to try out different version of emacs manually