### PR TITLE
Improved tag handling

### DIFF
--- a/mvtn-tag-addons.el
+++ b/mvtn-tag-addons.el
@@ -64,7 +64,11 @@ description after two colons (:)."
 
 (defun mvtn-cv-write-tag-to-file (tag &optional description)
   "Write a new TAG into `mvtn-cv-file' with DESCRIPTION."
-  (write-region (concat "\n" tag " :: " description) nil mvtn-cv-file t))
+  (let* ((contents (mvtn--get-string-from-file mvtn-cv-file))
+         (newline-at-end (or (string= contents "")
+                             (string= (substring contents -1) "\n"))))
+    (write-region (concat (if newline-at-end nil "\n") tag " :: " description)
+                  nil mvtn-cv-file t)))
 
 (defun mvtn--cv-multiaction-tag-prompt (tag)
   "Prompts for action regarding tags which aren't specified in `mvtn-cv-file'"

--- a/mvtn-tag-addons.el
+++ b/mvtn-tag-addons.el
@@ -71,7 +71,7 @@ description after two colons (:)."
                   nil mvtn-cv-file t)))
 
 (defun mvtn--cv-multiaction-tag-prompt (tag)
-  "Prompts for action regarding tags which aren't specified in `mvtn-cv-file'"
+  "Prompts for action for a TAG which is not specified in `mvtn-cv-file'."
   (if (and (>= emacs-major-version 16)
            (>= emacs-minor-version 2))
       (read-answer

--- a/mvtn-tag-addons.el
+++ b/mvtn-tag-addons.el
@@ -62,9 +62,9 @@ description after two colons (:)."
                          (match-string-no-properties 1 el)))
           (split-string (mvtn--get-string-from-file mvtn-cv-file) "\n")))
 
-(defun mvtn-cv-write-tag-to-file (tag)
-  "Write a new tage into `mvtn-cv-file'."
-  (write-region (concat "\n" tag " ::") nil mvtn-cv-file t))
+(defun mvtn-cv-write-tag-to-file (tag &optional description)
+  "Write a new TAG into `mvtn-cv-file' with DESCRIPTION."
+  (write-region (concat "\n" tag " :: " description) nil mvtn-cv-file t))
 
 (defun mvtn--cv-multiaction-tag-prompt (tag)
   "Prompts for action regarding tags which aren't specified in `mvtn-cv-file'"
@@ -106,20 +106,21 @@ inserted in the minibuffer."
            (taglist (completing-read-multiple "Tags (comma-separated): " cv
                                               nil nil initial))
            (continue-all nil)
-           (add-all nil))
+           (add-all nil)
+           (prompt-desc (lambda (tag) (read-from-minibuffer
+                                  (format "Description for new tag (%s): "
+                                          tag)))))
       (dolist (tag taglist)
         (unless (member tag cv)
           (let* ((read-answer-short t)
-                 (user-answer (cond (continue-all
-                                     "continue")
-                                    (add-all
-                                     "add")
+                 (user-answer (cond (continue-all "continue")
+                                    (add-all "add")
                                     (t (mvtn--cv-multiaction-tag-prompt tag)))))
             ;; Continue w/o adding this supplied tags
             (cond ((string= user-answer "continue"))
                   ;; Add this supplied tag to cv
                   ((string= user-answer "add")
-                   (mvtn-cv-write-tag-to-file tag))
+                   (mvtn-cv-write-tag-to-file tag (funcall prompt-desc tag)))
                   ;; Edit supplied tag list
                   ((string= user-answer "edit")
                    (setq taglist (mvtn-cv-prompt-for-tags
@@ -134,7 +135,7 @@ inserted in the minibuffer."
                    (setq continue-all t))
                   ;; Add all supplied tags to cv
                   ((string= user-answer "add all")
-                   (mvtn-cv-write-tag-to-file tag)
+                   (mvtn-cv-write-tag-to-file tag (funcall prompt-desc tag))
                    (setq add-all t))))))
       taglist)))
 

--- a/mvtn-tag-addons.el
+++ b/mvtn-tag-addons.el
@@ -103,32 +103,25 @@ inserted in the minibuffer."
                                     (add-all
                                      "add")
                                     (t (mvtn--cv-multiaction-tag-prompt el)))))
-            (message user-answer)
-            ;; Continue w/o adding this supplied taga
-            (cond ((string= user-answer "continue")
-                   (message "c was chosen"))
+            ;; Continue w/o adding this supplied tags
+            (cond ((string= user-answer "continue"))
                   ;; Add this supplied tag to cv
                   ((string= user-answer "add")
-                   (message "a was chosen")
                    (mvtn-cv-write-tag-to-file el))
                   ;; Edit supplied tag list
                   ((string= user-answer "edit")
-                   (message "e was chosen")
                    (setq answer (mvtn-cv-prompt-for-tags
-                                 (mapconcat 'identity answer ", ")))
+                                 (mapconcat 'identity answer ",")))
                    ;; Exit recursion
                    (throw 'ret answer))
                   ;; Remove from supplied tag list
                   ((string= user-answer "remove")
-                   (message "r was chosen")
                    (delete el answer))
                   ;; Continue w/o adding any supplied tag to cv
                   ((string= user-answer "continue all")
-                   (message "C was chosen")
                    (setq continue-all t))
                   ;; Add all supplied tags to cv
                   ((string= user-answer "add all")
-                   (message "A was chosen")
                    (mvtn-cv-write-tag-to-file el)
                    (setq add-all t))))))
       answer)))

--- a/mvtn-tag-addons.el
+++ b/mvtn-tag-addons.el
@@ -101,7 +101,8 @@ inserted in the minibuffer."
   ;; Allow for arbitrary return
   (catch 'ret
     (when (not (file-exists-p mvtn-cv-file))
-      (error "%s does not exist.  Please create it" mvtn-cv-file))
+      (mkdir (file-name-directory mvtn-cv-file) t)
+      (write-region "" nil mvtn-cv-file t))
     (let* ((cv (mvtn-cv-read-tags-from-file))
            (taglist (completing-read-multiple "Tags (comma-separated): " cv
                                               nil nil initial))


### PR DESCRIPTION
### Compatible with Emacs 26.1 or later

**New features:**
- [x] Continue w/o adding new tag to controlled vocabulary
- [x] Continue and add new tag to controlled vocabulary
- [x] Continue w/o adding for all other supplied tags
- [x] Continue and add for all other supplied tags
- [x] Remove tag from supplied tag list
- [x] Edit supplied tag list